### PR TITLE
fix "item is not defined" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,7 +301,7 @@ function convertVectorDrawableColor(color, alpha, attributes, colorName, opacity
         });
     } else {
         result.elements = [];
-
+        var item = color;
         if (item.startColor !== null) {
             result.elements.push(
                 {


### PR DESCRIPTION
when gradient defined like this:
<aapt:attr name="android:fillColor">
    <gradient
        android:endX="33.5"
        android:endY="16.5"
        android:startX="0.5"
        android:startY="16.5"
        android:type="linear"
        android:startColor="#FFE9541D"
        android:endColor="#FFEA2200"
    </gradient>
</aapt:attr>